### PR TITLE
Validation API

### DIFF
--- a/Example/Tests/ViewControllerSpec.swift
+++ b/Example/Tests/ViewControllerSpec.swift
@@ -35,6 +35,14 @@ class ViewControllerSpec: QuickSpec {
 				viewController.loadView()
 				expect(viewController.view).toNot(beNil())
 
+                setupActionValidator { target, action, expectedAction in
+                    expect(target) === viewController
+                    expect(action).toNot(beNil())
+                    if let action = action {
+                        expect(action) == expectedAction
+                    }
+                }
+
 				// Capture the new viewController instance for each test
 				hasBarButtonItemOutlet = outlet(viewController)
 				hasSegmentedControlOutlet = outlet(viewController)

--- a/Example/Tests/ViewControllerSpec.swift
+++ b/Example/Tests/ViewControllerSpec.swift
@@ -15,6 +15,14 @@ import Nimble
 
 class ViewControllerSpec: QuickSpec {
 	override func spec() {
+        setupFailHandler { message in
+            if let message = message {
+                fail(message)
+            } else {
+                fail()
+            }
+        }
+
 		var viewController: UIViewController!
 
 		var hasBarButtonItemOutlet: BarButtonItemOutletAssertion!

--- a/Outlets.xcodeproj/project.pbxproj
+++ b/Outlets.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B585CE051CD7EAFF001A701E /* Validation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B585CE041CD7EAFF001A701E /* Validation.swift */; };
 		F8325C331CD67E78001189AF /* Outlets.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F8325C281CD67E77001189AF /* Outlets.framework */; };
 		F8325C381CD67E78001189AF /* OutletsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8325C371CD67E78001189AF /* OutletsTests.swift */; };
 		F8325C511CD688E7001189AF /* Action.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8325C4E1CD688E7001189AF /* Action.swift */; };
-		F8325C521CD688E7001189AF /* Common.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8325C4F1CD688E7001189AF /* Common.swift */; };
 		F8325C531CD688E7001189AF /* Outlet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8325C501CD688E7001189AF /* Outlet.swift */; };
 		F8325C551CD68915001189AF /* Outlets.h in Headers */ = {isa = PBXBuildFile; fileRef = F8325C541CD68915001189AF /* Outlets.h */; settings = {ATTRIBUTES = (Public, ); }; };
 /* End PBXBuildFile section */
@@ -26,13 +26,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B585CE041CD7EAFF001A701E /* Validation.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Validation.swift; sourceTree = "<group>"; };
 		F8325C281CD67E77001189AF /* Outlets.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Outlets.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8325C2D1CD67E78001189AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8325C321CD67E78001189AF /* OutletsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = OutletsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8325C371CD67E78001189AF /* OutletsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutletsTests.swift; sourceTree = "<group>"; };
 		F8325C391CD67E78001189AF /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F8325C4E1CD688E7001189AF /* Action.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Action.swift; sourceTree = "<group>"; };
-		F8325C4F1CD688E7001189AF /* Common.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Common.swift; sourceTree = "<group>"; };
 		F8325C501CD688E7001189AF /* Outlet.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Outlet.swift; sourceTree = "<group>"; };
 		F8325C541CD68915001189AF /* Outlets.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Outlets.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -96,9 +96,9 @@
 			isa = PBXGroup;
 			children = (
 				F8325C4E1CD688E7001189AF /* Action.swift */,
-				F8325C4F1CD688E7001189AF /* Common.swift */,
 				F8325C501CD688E7001189AF /* Outlet.swift */,
 				F8325C541CD68915001189AF /* Outlets.h */,
+				B585CE041CD7EAFF001A701E /* Validation.swift */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -213,7 +213,7 @@
 			files = (
 				F8325C531CD688E7001189AF /* Outlet.swift in Sources */,
 				F8325C511CD688E7001189AF /* Action.swift in Sources */,
-				F8325C521CD688E7001189AF /* Common.swift in Sources */,
+				B585CE051CD7EAFF001A701E /* Validation.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Outlets/Source/Action.swift
+++ b/Outlets/Source/Action.swift
@@ -72,10 +72,6 @@ public func action(viewController: UIViewController) -> (String, from: String) -
             }
         }
 
-//        expect(target) === viewController
-//        expect(action).toNot(beNil())
-//        if let action = action {
-//            expect(action) == expectedAction
-//        }
+        validate(target: target, action: action, expectedAction: expectedAction)
     }
 }

--- a/Outlets/Source/Common.swift
+++ b/Outlets/Source/Common.swift
@@ -6,21 +6,73 @@
 //  Copyright © 2016 Ben Chatelain. All rights reserved.
 //
 
+// MARK: - Failure Handling
+
 /// Closure called when a test has failed. Used to map to testing framework's
 /// fail function.
 public typealias FailHandler = String? -> Void
 
 private var failHandler: FailHandler?
 
+/// Stores the given `FailHandler` for use when a built-in validation fails.
+/// Example of calling this with trailing closure syntax and mapping to the
+/// Nimble `fail` function:
+///
+///     setupFailHandler { message in
+///         if let message = message {
+///             fail(message)
+///         } else {
+///             fail()
+///         }
+///     }
+///
+/// - parameter handler: Optional `FailHandler` to handle failures.
 public func setupFailHandler(handler: FailHandler?) {
     failHandler = handler
 }
 
-/// No-op function which will eventually be mapped to Nimble fail()
-/// or XCTFail() (can this be done dynamically?)
+/// Passthrough function which calls the `FailHandler` provided by the caller.
+/// This allows for tests to call XCTFail() or Nimble's fail() function without
+/// any knowledge or dependencies in this framework.
 ///
-/// - parameter message: Description of failure.
+/// - parameter message: Optional description of failure.
 func fail(message: String?) {
-    guard let handler = failHandler else { print("ERROR: failHandler has not been set up"); return }
+    guard let handler = failHandler else { print("ERROR: failHandler has not been set up."); return }
     handler(message)
+}
+
+// MARK: - Action Validation
+public typealias ActionValidation = (target: AnyObject?, action: String?, expectedAction: String) -> Void
+
+private var actionValidator: ActionValidation?
+
+/// Stores the given `ActionValidation` for use in validating IBAction methods.
+/// Example of calling this with trailing closure syntax and mapping to the
+/// Nimble `expect` function:
+///
+///     setupActionValidator { target, action, expectedAction in
+///         expect(target) === viewController
+///         expect(action).toNot(beNil())
+///         if let action = action {
+///             expect(action) == expectedAction
+///         }
+///     }
+///
+/// - parameter validator: Optional `ActionValidation` to perform validation.
+/// - Note: The `validator` should be passed the same `UIViewController` instance that will be
+///         used in your tests. If you reinitialize this for each text/example method (e.g. in
+///         `setUp` or `beforeEach`) you will need to call `setupActionValidator` again with
+///         the new instance.
+public func setupActionValidator(validator: ActionValidation?) {
+    actionValidator = validator
+}
+
+/// Passthrough function which calls the `ActionValidation` provided by the caller.
+///
+/// - parameter target:         Target of the action, expected to be the given view controller.
+/// - parameter action:         Action found (will be nil if not found).
+/// - parameter expectedAction: String name of expected action.
+func validate(target target: AnyObject?, action: String?, expectedAction: String) {
+    guard let validator = actionValidator else { print("ERROR: actionValidator has not been set up."); return }
+    validator(target: target, action: action, expectedAction: expectedAction)
 }

--- a/Outlets/Source/Common.swift
+++ b/Outlets/Source/Common.swift
@@ -6,8 +6,21 @@
 //  Copyright © 2016 Ben Chatelain. All rights reserved.
 //
 
+/// Closure called when a test has failed. Used to map to testing framework's
+/// fail function.
+public typealias FailHandler = String? -> Void
+
+private var failHandler: FailHandler?
+
+public func setupFailHandler(handler: FailHandler?) {
+    failHandler = handler
+}
+
 /// No-op function which will eventually be mapped to Nimble fail()
 /// or XCTFail() (can this be done dynamically?)
 ///
 /// - parameter message: Description of failure.
-func fail(message: String?) {}
+func fail(message: String?) {
+    guard let handler = failHandler else { print("ERROR: failHandler has not been set up"); return }
+    handler(message)
+}

--- a/Outlets/Source/Outlet.swift
+++ b/Outlets/Source/Outlet.swift
@@ -58,10 +58,13 @@ typealias ImageOutletAssertion = String -> UIImageView?
 ///            - parameter outlet: Name of outlet to look up.
 ///
 ///            - returns: Object bound to `outlet` if found; nil otherwise.
+///
+/// - note: Does not need an explicit call to test framework fail as runtime will catch exception:
+///         Assertions: failed: caught "NSUnknownKeyException", "[<OutletsExample.ViewController 0x7fa400c47750> valueForUndefinedKey:]: this class is not key value coding-compliant for the key leftButton1."
 func outlet(viewController: UIViewController) -> (String) -> AnyObject? {
     return { (outlet: String) -> AnyObject? in
         guard let object = viewController.valueForKey(outlet)
-            else { fail("\(outlet) outlet was nil"); return nil }
+            else { return nil }
 
         return object
     }

--- a/Outlets/Source/Validation.swift
+++ b/Outlets/Source/Validation.swift
@@ -1,5 +1,5 @@
 //
-//  Common.swift
+//  Validation.swift
 //  Outlets
 //
 //  Created by Ben Chatelain on 5/1/16.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,75 @@ Utility functions for validating IBOutlet and IBAction connections.
 
 To run the example project, clone the repo, and run `pod install` from the Example directory first.
 
+Here is an example of using Outlets with Quick and Nimble:
+
+```swift
+class ViewControllerSpec: QuickSpec {
+	override func spec() {
+        setupFailHandler { message in
+            if let message = message {
+                fail(message)
+            } else {
+                fail()
+            }
+        }
+
+		var viewController: UIViewController!
+
+		var hasBarButtonItemOutlet: BarButtonItemOutletAssertion!
+		var hasSegmentedControlOutlet: SegmentedControlOutletAssertion!
+		var receivesAction: ActionAssertion!
+
+		describe("view controller") {
+			beforeEach {
+				viewController = UIStoryboard(name: "Main", bundle: nil).instantiateViewControllerWithIdentifier("ViewController")
+				viewController.loadView()
+				expect(viewController.view).toNot(beNil())
+
+                setupActionValidator { target, action, expectedAction in
+                    expect(target) === viewController
+                    expect(action).toNot(beNil())
+                    if let action = action {
+                        expect(action) == expectedAction
+                    }
+                }
+
+				// Capture the new viewController instance for each test
+				hasBarButtonItemOutlet = outlet(viewController)
+				hasSegmentedControlOutlet = outlet(viewController)
+				receivesAction = action(viewController)
+			}
+
+			// MARK: - Outlets
+			it("has a leftButton outlet") {
+				hasBarButtonItemOutlet("leftButton")
+			}
+			it("has a rightButton outlet") {
+				hasBarButtonItemOutlet("rightButton")
+			}
+			it("has a segmentedControl outlet") {
+				hasSegmentedControlOutlet("segmentedControl")
+			}
+
+			// MARK: - Actions
+			it("receives a didTapLeftButton: action from leftButton") {
+				receivesAction("didTapLeftButton:", from: "leftButton")
+			}
+			it("receives a didTapRightButton: action from rightButton") {
+				receivesAction("didTapRightButton:", from: "rightButton")
+			}
+			it("receives a segmentedControlValueDidChange: action from segmentedControl") {
+				receivesAction("segmentedControlValueDidChange:", from: "segmentedControl")
+			}
+		}
+	}
+}
+```
+
 ## Requirements
+
+- Xcode 7.3+
+- CocoaPods 0.39+
 
 ## Installation
 
@@ -24,7 +92,7 @@ pod "Outlets"
 
 ## Author
 
-Ben Chatelain, ben@octop.ad
+Ben Chatelain, [@phatblat](https://twitter.com/phatblat)
 
 ## License
 


### PR DESCRIPTION
To keep Outlets lightweight (no dependencies), two API have been added for calling tests to hook in their own validation:
- `setupFailHandler`
- `setupActionValidator`

If provided, the `FailHandler` gets called when an outlet cannot be cast to the expected type. It may get used in other cases in the future. It is very generic, simply passing along any provided message string to the handler block for logging or passing along to `XCTFail` or the Nimble `fail` function.

If provided, the `ActionValidation` gets called to validate an action.

For now, if either of these handlers are not provided an error is printed to the test console log. This currently doesn't cause the test to fail, which may be a better experience. This should probably be changed to throw an error instead.
